### PR TITLE
add a non-memfd_create enabled build for each release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ vendor/pkg
 contrib/cmd/recvtty/recvtty
 man/man8
 release
+dist

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,9 +32,11 @@ RUN for VER in v1.12.6 v1.13.1 v17.03.2 v17.06.2 v17.09.1 v17.12.1 v18.03.1 v18.
     git checkout release-${VER} && \
     for GOARCH in $(go env GOARCH); do \
         export GOARCH && \
-        make BUILDTAGS="seccomp selinux apparmor" static && \
         mkdir -p dist && \
-        mv runc dist/runc-${VER}-${GOARCH} \
+        make BUILDTAGS="seccomp selinux apparmor" static && \
+        mv runc dist/runc-${VER}-${GOARCH} && \
+        make CGO_CFLAGS="-DDISABLE_MEMFD_CREATE=1" BUILDTAGS="seccomp selinux apparmor" static && \
+        mv runc dist/runc-${VER}-${GOARCH}-no-memfd_create \
     ; done ; done && \
     cd dist && \
     sha256sum * > sha256sum-${GOARCH}.txt


### PR DESCRIPTION
We have some hosts that are pre-memfd_create backport versions of kernel 3.x still. The upstream runc patch has support for using a tempfile instead of memfd, which I backported here. I also added a macro to be able to explicitly toggle so that binaries can be created with that feature explicitly off.

https://github.com/rancher/runc-cve/compare/release-v1.12.6...steved:release-v1.12.6
https://github.com/rancher/runc-cve/compare/release-v1.13.1...steved:release-v1.13.1
https://github.com/rancher/runc-cve/compare/release-v17.03.2...steved:release-v17.03.2
https://github.com/rancher/runc-cve/compare/release-v17.06.2...steved:release-v17.06.2
https://github.com/rancher/runc-cve/compare/release-v17.09.1...steved:release-v17.09.1
https://github.com/rancher/runc-cve/compare/release-v17.12.1...steved:release-v17.12.1
https://github.com/rancher/runc-cve/compare/release-v18.03.1...steved:release-v18.03.1
https://github.com/rancher/runc-cve/compare/release-v18.06.1...steved:release-v18.06.1